### PR TITLE
Change Argo CD tracking label

### DIFF
--- a/pkg/argocd/configmap.go
+++ b/pkg/argocd/configmap.go
@@ -67,8 +67,9 @@ func createArgoCDConfigMaps(gitInfo *api.GitInfo, clientset *kubernetes.Clientse
 			Labels: cmLabel,
 		},
 		Data: map[string]string{
-			"repositories":            fmt.Sprintf(repoString, gitInfo.URL, argoSSHSecretName, argoSSHPrivateKey),
-			"configManagementPlugins": pluginString,
+			"repositories":                 fmt.Sprintf(repoString, gitInfo.URL, argoSSHSecretName, argoSSHPrivateKey),
+			"configManagementPlugins":      pluginString,
+			"application.instanceLabelKey": "argocd.argoproj.io/instance",
 		},
 	}
 


### PR DESCRIPTION
Since the default label collides with some other defaults [1].

[1] https://argoproj.github.io/argo-cd/faq/#why-is-my-app-out-of-sync-even-after-syncing

Signed-off-by: Simon Rüegg <simon.ruegg@vshn.ch>