### PR TITLE
Use Argo CD 1.4.2 by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 	app.Flag("region", "Cloud region this cluster is running in").StringVar(&agent.CloudRegion)
 	app.Flag("distribution", "Kubernetes distribution this cluster is running").StringVar(&agent.Distribution)
 	app.Flag("namespace", "Namespace in which steward is running").Default("syn").StringVar(&agent.Namespace)
-	app.Flag("argo-image", "Image to be used for the Argo CD deployments").Default("docker.io/argoproj/argocd:v1.3.6").StringVar(&agent.ArgoCDImage)
+	app.Flag("argo-image", "Image to be used for the Argo CD deployments").Default("docker.io/argoproj/argocd:v1.4.2").StringVar(&agent.ArgoCDImage)
 
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 }


### PR DESCRIPTION
Use the latest and greatest Argo CD also for bootstrapping.