### PR TITLE
Use custom label on Argo CD resources

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -13,8 +13,8 @@ import (
 
 var (
 	argoLabels = map[string]string{
-		"app.kubernetes.io/part-of":  "argocd",
-		"app.kubernetes.io/instance": "argocd",
+		"app.kubernetes.io/part-of":   "argocd",
+		"argocd.argoproj.io/instance": "argocd",
 	}
 	argoSSHSecretName     = "argo-ssh-key"
 	argoSSHPublicKey      = "sshPublicKey"


### PR DESCRIPTION
Since we changed the default for Argo CD to
`argocd.argoproj.io/instance` to not interfer with other labels.
