### PR TITLE
Upgraded antora-preview to latest version with live reloading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ docker_cmd  ?= docker
 docker_opts ?= --rm --tty --user "$$(id -u)"
 
 vale_cmd           ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}"/docs/modules/ROOT/pages:/pages vshn/vale:2.1.1 --minAlertLevel=error --config=/pages/.vale.ini /pages
-antora_preview_cmd ?= $(docker_cmd) run --rm --publish 2020:2020 --volume "${PWD}":/antora vshn/antora-preview:2.3.3 --style=syn --antora=docs
+antora_preview_cmd ?= $(docker_cmd) run --rm --publish 35729:35729 --publish 2020:2020 --volume "${PWD}":/preview/antora vshn/antora-preview:2.3.4 --style=syn --antora=docs
 
 # Go parameters
 GOCMD   ?= go


### PR DESCRIPTION
This PR provides upgrades antora-preview to the last version (2.3.4) which includes a new live reloading capability:

1. Run `make docs-serve`.
2. Open http://localhost:2020 on a browser with the [LiveReload plugin](https://github.com/vshn/antora-preview#livereload).
3. Edit your documentation in your preferred editor.
4. Watch your changes appear automatically on the browser.