### PR TITLE
Reduce Argo CD secret already exists log level

### DIFF
--- a/pkg/argocd/secret.go
+++ b/pkg/argocd/secret.go
@@ -36,7 +36,7 @@ func CreateArgoSecret(config *rest.Config, namespace, password string) error {
 		currentPwHash := secret.Data["admin.password"]
 		err = bcrypt.CompareHashAndPassword(currentPwHash, []byte(password))
 		if err == nil {
-			klog.Warning("Argo CD secret already exists, no update needed")
+			klog.Info("Argo CD secret already exists, no update needed")
 			return nil
 		}
 		if secret.StringData == nil {


### PR DESCRIPTION
This is an info and no warning. This message is logged every
minute and uses a lot of space in the log mechanism.