### PR TITLE
Switch Application-Controller and Repo-Server to StatefulSet

### DIFF
--- a/pkg/argocd/app-controller.go
+++ b/pkg/argocd/app-controller.go
@@ -11,8 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func int32Ptr(i int32) *int32 { return &i }
-
 func createApplicationControllerStatefulSet(clientset *kubernetes.Clientset, namespace, argoImage string) error {
 	name := "argocd-application-controller"
 	labels := map[string]string{

--- a/pkg/argocd/app-controller.go
+++ b/pkg/argocd/app-controller.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	// TODO: Switch to utilpointer "k8s.io/utils/pointer"
 )
 
 func int32Ptr(i int32) *int32 { return &i }
@@ -30,8 +29,6 @@ func createApplicationControllerStatefulSet(clientset *kubernetes.Clientset, nam
 			Labels:    labels,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			// Replicas: utilpointer.Int32Ptr(1),
-			Replicas: int32Ptr(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app.kubernetes.io/name": name,
@@ -86,34 +83,6 @@ func createApplicationControllerStatefulSet(clientset *kubernetes.Clientset, nam
 								},
 								InitialDelaySeconds: 5,
 								PeriodSeconds:       10,
-							},
-						},
-					},
-					Affinity: &corev1.Affinity{
-						PodAntiAffinity: &corev1.PodAntiAffinity{
-							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-								{
-									PodAffinityTerm: corev1.PodAffinityTerm{
-										LabelSelector: &metav1.LabelSelector{
-											MatchLabels: map[string]string{
-												"app.kubernetes.io/name": name,
-											},
-										},
-										TopologyKey: "kubernetes.io/hostname",
-									},
-									Weight: 100,
-								},
-								{
-									PodAffinityTerm: corev1.PodAffinityTerm{
-										LabelSelector: &metav1.LabelSelector{
-											MatchLabels: map[string]string{
-												"app.kubernetes.io/part-of": "argocd",
-											},
-										},
-										TopologyKey: "kubernetes.io/hostname",
-									},
-									Weight: 5,
-								},
 							},
 						},
 					},

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -46,10 +46,6 @@ func Apply(ctx context.Context, config *rest.Config, namespace, argoImage string
 	}
 	expectedDeploymentCount := 3
 	foundDeploymentCount := len(deployments.Items)
-	if foundDeploymentCount == expectedDeploymentCount {
-		klog.Infof("Found %d of %d deployments", foundDeploymentCount, expectedDeploymentCount)
-		return nil
-	}
 
 	statefulsets, err := clientset.AppsV1().StatefulSets(namespace).List(metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/part-of=argocd",
@@ -59,10 +55,12 @@ func Apply(ctx context.Context, config *rest.Config, namespace, argoImage string
 	}
 	expectedStatefulSetCount := 1
 	foundStatefulSetCount := len(statefulsets.Items)
-	if foundStatefulSetCount == expectedStatefulSetCount {
-		klog.Infof("Found %d of %d statefulsets", foundStatefulSetCount, expectedStatefulSetCount)
+
+	if foundDeploymentCount == expectedDeploymentCount && foundStatefulSetCount == expectedStatefulSetCount {
+		klog.Infof("Found %d of expected %d deployments, found %d of expected %d statefulsets, skip", foundDeploymentCount, expectedDeploymentCount, foundStatefulSetCount, expectedStatefulSetCount)
 		return nil
 	}
+
 	klog.Infof("Found %d of expected %d deployments, found %d of expected %d statefulsets, bootstrapping now", foundDeploymentCount, expectedDeploymentCount, foundStatefulSetCount, expectedStatefulSetCount)
 	return bootstrapArgo(ctx, clientset, config, namespace, argoImage, apiClient, cluster)
 }

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -57,7 +57,7 @@ func Apply(ctx context.Context, config *rest.Config, namespace, argoImage string
 	foundStatefulSetCount := len(statefulsets.Items)
 
 	if foundDeploymentCount == expectedDeploymentCount && foundStatefulSetCount == expectedStatefulSetCount {
-		klog.Infof("Found %d of expected %d deployments, found %d of expected %d statefulsets, skip", foundDeploymentCount, expectedDeploymentCount, foundStatefulSetCount, expectedStatefulSetCount)
+		// Found expected deployments, found expected statefulsets, skip
 		return nil
 	}
 

--- a/pkg/argocd/redis.go
+++ b/pkg/argocd/redis.go
@@ -60,6 +60,7 @@ func createRedisDeployment(clientset *kubernetes.Clientset, namespace, argoImage
 					},
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName: "steward",
 					Containers: []corev1.Container{
 						corev1.Container{
 							Name:  "redis",

--- a/pkg/argocd/repo-server.go
+++ b/pkg/argocd/repo-server.go
@@ -141,34 +141,6 @@ func createRepoServerDeployment(clientset *kubernetes.Clientset, namespace, argo
 							},
 						},
 					},
-					Affinity: &corev1.Affinity{
-						PodAntiAffinity: &corev1.PodAntiAffinity{
-							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-								{
-									PodAffinityTerm: corev1.PodAffinityTerm{
-										LabelSelector: &metav1.LabelSelector{
-											MatchLabels: map[string]string{
-												"app.kubernetes.io/name": name,
-											},
-										},
-										TopologyKey: "kubernetes.io/hostname",
-									},
-									Weight: 100,
-								},
-								{
-									PodAffinityTerm: corev1.PodAffinityTerm{
-										LabelSelector: &metav1.LabelSelector{
-											MatchLabels: map[string]string{
-												"app.kubernetes.io/part-of": "argocd",
-											},
-										},
-										TopologyKey: "kubernetes.io/hostname",
-									},
-									Weight: 5,
-								},
-							},
-						},
-					},
 				},
 			},
 		},

--- a/pkg/argocd/repo-server.go
+++ b/pkg/argocd/repo-server.go
@@ -116,25 +116,56 @@ func createRepoServerDeployment(clientset *kubernetes.Clientset, namespace, argo
 							},
 							LivenessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
-									TCPSocket: &corev1.TCPSocketAction{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/healthz?full=true",
 										Port: intstr.IntOrString{
-											IntVal: 8081,
+											IntVal: 8084,
 										},
 									},
 								},
-								InitialDelaySeconds: 60,
-								PeriodSeconds:       10,
+								InitialDelaySeconds: 30,
+								PeriodSeconds:       5,
+								FailureThreshold:    3,
 							},
 							ReadinessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
-									TCPSocket: &corev1.TCPSocketAction{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/healthz",
 										Port: intstr.IntOrString{
-											IntVal: 8081,
+											IntVal: 8084,
 										},
 									},
 								},
-								InitialDelaySeconds: 1,
+								InitialDelaySeconds: 5,
 								PeriodSeconds:       10,
+							},
+						},
+					},
+					Affinity: &corev1.Affinity{
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+								{
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"app.kubernetes.io/name": name,
+											},
+										},
+										TopologyKey: "kubernetes.io/hostname",
+									},
+									Weight: 100,
+								},
+								{
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"app.kubernetes.io/part-of": "argocd",
+											},
+										},
+										TopologyKey: "kubernetes.io/hostname",
+									},
+									Weight: 5,
+								},
 							},
 						},
 					},


### PR DESCRIPTION
The deployment strategy of ArgoCD 1.8 has changed.

Ref: https://argoproj.github.io/argo-cd/operator-manual/upgrading/1.7-1.8/#the-argocd-application-controller-converted-to-statefulset