### PR TITLE
Change set-env in workflow push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,10 +15,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Set version latest
       if: github.ref == 'refs/heads/master'
-      run: echo ::set-env name=VERSION::latest
+      run: echo "VERSION=latest" >> ${GITHUB_ENV}
     - name: Set version from tag
       if: startsWith(github.ref, 'refs/tags/v')
-      run: echo ::set-env name=VERSION::$(echo ${GITHUB_REF#refs/tags/})
+      run: echo "VERSION=$(echo ${GITHUB_REF#refs/tags/})" >> ${GITHUB_ENV}
     - name: Build Image
       run: make docker
       env:


### PR DESCRIPTION
Unable to process command '::set-env name=VERSION::latest'.

GitHub no longer execute set-env.