### PR TITLE
Add ServiceName for ArgoCD App Controler Statefulset

### DIFF
--- a/pkg/argocd/app-controller.go
+++ b/pkg/argocd/app-controller.go
@@ -32,6 +32,7 @@ func createApplicationControllerStatefulSet(clientset *kubernetes.Clientset, nam
 					"app.kubernetes.io/name": name,
 				},
 			},
+			ServiceName: "argocd-application-controller",
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{


### PR DESCRIPTION
The spec.serviceName field can not be changed after the
statefulset object has been created. ArgoCD does stuck
updating the statefulset via the argocd Project Syn component.