### PR TITLE
Remove message Argo CD secret already exists

### DIFF
--- a/pkg/argocd/secret.go
+++ b/pkg/argocd/secret.go
@@ -36,7 +36,6 @@ func CreateArgoSecret(config *rest.Config, namespace, password string) error {
 		currentPwHash := secret.Data["admin.password"]
 		err = bcrypt.CompareHashAndPassword(currentPwHash, []byte(password))
 		if err == nil {
-			klog.Info("Argo CD secret already exists, no update needed")
 			return nil
 		}
 		if secret.StringData == nil {


### PR DESCRIPTION
The message is triggered every minute. This causes
43200 log messages per month have to be stored.