### PR TITLE
Revert "Use Bitnami Redis from quay.io"

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ var Version = "unreleased"
 
 const (
 	DefaultArgoCDImage = "quay.io/argoproj/argocd:v2.0.4@sha256:976dfbfadb817ba59f4f641597a13df7b967cd5a1059c966fa843869c9463348"
-	DefaultRedisImage  = "quay.io/bitnami/redis:6.2.4"
+	DefaultRedisImage  = "docker.io/redis:6.2.4@sha256:f631ff6c898339306ffdb8369add5c12303ec3946610ef8d6f1d05f575942f0c"
 )
 
 func main() {

--- a/pkg/argocd/redis.go
+++ b/pkg/argocd/redis.go
@@ -67,10 +67,11 @@ func createRedisDeployment(ctx context.Context, clientset *kubernetes.Clientset,
 						corev1.Container{
 							Name:  "redis",
 							Image: redisImage,
-							Env: []corev1.EnvVar{
-								{Name: "ALLOW_EMPTY_PASSWORD", Value: "yes"},
-								{Name: "REDIS_AOF_ENABLED", Value: "no"},
-								{Name: "REDIS_EXTRA_FLAGS", Value: "--save ''"},
+							Args: []string{
+								"--save",
+								"",
+								"--appendonly",
+								"no",
 							},
 							Ports: []corev1.ContainerPort{
 								corev1.ContainerPort{


### PR DESCRIPTION
We removed bitnami/redis support from [`component-argocd`](https://github.com/projectsyn/component-argocd/pull/45) since the permissions were broken and we had a global override to switch back to the official dockerhub image.

Reverts projectsyn/steward#82