### PR TITLE
Download manifests for saved ArgoCD version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '>=1.18.0'
     - name: Go generate
       run: make generate
     - name: Check for uncommited differences
-      run: git diff --exit-code -- manifests/
+      run: git diff --exit-code -- manifests/ || ( echo 'Please run `go generate ./...`' ; exit 3 )
 
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,22 @@ on:
     - master
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Go generate
+      run: make generate
+    - name: Check for uncommited differences
+      run: git diff --exit-code -- manifests/
+
   tests:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Build image
       run: make docker
+
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ antora_preview_cmd ?= $(docker_cmd) run --rm --publish 35729:35729 --publish 202
 # Go parameters
 GOCMD   ?= go
 GOBUILD ?= $(GOCMD) build
+GOGEN   ?= $(GOCMD) generate
 GOCLEAN ?= $(GOCMD) clean
 GOTEST  ?= $(GOCMD) test
 GOGET   ?= $(GOCMD) get
@@ -21,15 +22,19 @@ GOGET   ?= $(GOCMD) get
 .PHONY: all
 all: test build docs
 
+.PHONY: generate
+generate:
+	$(GOGEN) ./...
+
 .PHONY: build
-build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -v \
+build: generate
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) \
 		-o $(BINARY_NAME) \
 		-ldflags "-X main.Version=$(VERSION)"
 	@echo built '$(VERSION)'
 
 .PHONY: test
-test:
+test: generate
 	$(GOTEST) -v ./...
 
 .PHONY: clean

--- a/build/download-manifests/main.go
+++ b/build/download-manifests/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/projectsyn/steward/pkg/images"
+)
+
+var crds = []string{
+	"https://raw.githubusercontent.com/argoproj/argo-cd/{{VERSION}}/manifests/crds/application-crd.yaml",
+	"https://raw.githubusercontent.com/argoproj/argo-cd/{{VERSION}}/manifests/crds/appproject-crd.yaml",
+}
+
+func main() {
+	path, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	version, err := version(images.DefaultArgoCDImage)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, urlTmpl := range crds {
+		err := download(strings.Replace(urlTmpl, "{{VERSION}}", version, -1), path+"/manifests/")
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func version(img string) (string, error) {
+	_, version, found := strings.Cut(img, ":")
+
+	if !found {
+		return "", fmt.Errorf("Invalid format, expected to find ':' image: %s", images.DefaultArgoCDImage)
+	}
+
+	return version, nil
+}
+
+func download(url string, dir string) error {
+	r, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+	f, err := os.Create(dir + filepath.Base(url))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	fmt.Fprintln(f, "# This file is overridden with `go generate`. DO NOT EDIT.")
+	fmt.Fprintln(f, "# Download using go generate ./...")
+	fmt.Fprintf(f, "# url: %s\n", url)
+	io.Copy(f, r.Body)
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+//go:generate go run ./build/download-manifests
 package main
 
 import (
@@ -10,6 +11,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/projectsyn/steward/pkg/agent"
+	"github.com/projectsyn/steward/pkg/images"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -43,8 +45,8 @@ func main() {
 	app.Flag("region", "Cloud region this cluster is running in").StringVar(&agent.CloudRegion)
 	app.Flag("distribution", "Kubernetes distribution this cluster is running").StringVar(&agent.Distribution)
 	app.Flag("namespace", "Namespace in which steward is running").Default("syn").StringVar(&agent.Namespace)
-	app.Flag("argo-image", "Image to be used for the Argo CD deployments").Default(DefaultArgoCDImage).StringVar(&agent.ArgoCDImage)
-	app.Flag("redis-image", "Image to be used for the Argo CD Redis deployment").Default(DefaultRedisImage).StringVar(&agent.RedisImage)
+	app.Flag("argo-image", "Image to be used for the Argo CD deployments").Default(images.DefaultArgoCDImage).StringVar(&agent.ArgoCDImage)
+	app.Flag("redis-image", "Image to be used for the Argo CD Redis deployment").Default(images.DefaultRedisImage).StringVar(&agent.RedisImage)
 
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 }

--- a/manifests/application-crd.yaml
+++ b/manifests/application-crd.yaml
@@ -1,4 +1,6 @@
-# https://raw.githubusercontent.com/argoproj/argo-cd/v2.3.4/manifests/crds/application-crd.yaml
+# This file is overridden with `go generate`. DO NOT EDIT.
+# Download using go generate ./...
+# url: https://raw.githubusercontent.com/argoproj/argo-cd/v2.3.4/manifests/crds/application-crd.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/manifests/appproject-crd.yaml
+++ b/manifests/appproject-crd.yaml
@@ -1,4 +1,6 @@
-# https://raw.githubusercontent.com/argoproj/argo-cd/v2.3.4/manifests/crds/appproject-crd.yaml
+# This file is overridden with `go generate`. DO NOT EDIT.
+# Download using go generate ./...
+# url: https://raw.githubusercontent.com/argoproj/argo-cd/v2.3.4/manifests/crds/appproject-crd.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -1,4 +1,4 @@
-package main
+package images
 
 // WARNING: Renovate updates the images in this file. If adding changes double check the
 // renovate.json file and it's regexManagers.

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
   ],
   "regexManagers": [
     {
-      "fileMatch": ["^images.go$"],
+      "fileMatch": ["^pkg/images/images.go$"],
       "matchStrings": [
         "\\tDefault.*?Image\\s+= \"(?<depName>.*?):(?<currentValue>.*?)\"(\n|$)"
       ],


### PR DESCRIPTION
This PR:
* Adds a `go:generate` statement to download Argo CRDs
* Adds the `make generate` target
* Adds a linting step to check if CRDs are up-to-date.

Note: It is not possible to download the CRDs using Github's Renovate. Defining post upgrade tasks for only possible for self-hosted.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
