### PR TITLE
Update ArgoCD to v2.3.12

### DIFF
--- a/manifests/application-crd.yaml
+++ b/manifests/application-crd.yaml
@@ -1,6 +1,6 @@
 # This file is overridden with `go generate`. DO NOT EDIT.
 # Download using go generate ./...
-# url: https://raw.githubusercontent.com/argoproj/argo-cd/v2.3.4/manifests/crds/application-crd.yaml
+# url: https://raw.githubusercontent.com/argoproj/argo-cd/v2.3.12/manifests/crds/application-crd.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/manifests/appproject-crd.yaml
+++ b/manifests/appproject-crd.yaml
@@ -1,6 +1,6 @@
 # This file is overridden with `go generate`. DO NOT EDIT.
 # Download using go generate ./...
-# url: https://raw.githubusercontent.com/argoproj/argo-cd/v2.3.4/manifests/crds/appproject-crd.yaml
+# url: https://raw.githubusercontent.com/argoproj/argo-cd/v2.3.12/manifests/crds/appproject-crd.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -6,6 +6,6 @@ package images
 const (
 	// DefaultArgoCDImage is the default image to use for the ArgoCD deployment.
 	// You should also update the CRDs in the manifests/ directory to match this version.
-	DefaultArgoCDImage = "quay.io/argoproj/argocd:v2.3.4"
-	DefaultRedisImage  = "docker.io/redis:6.2.4"
+	DefaultArgoCDImage = "quay.io/argoproj/argocd:v2.3.12"
+	DefaultRedisImage  = "docker.io/redis:6.2.6"
 )


### PR DESCRIPTION
We need ArgoCD v2.3.7 or newer in order to properly support Git servers which run OpenSSH 8.8 or newer, cf.
https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.3-2.4/#support-for-private-repo-ssh-keys-using-the-sha-1-signature-hash-algorithm-is-removed

We need to update this in Steward itself, as otherwise the initial bootstrapping of clusters connected to GitLab instances which run OpenSSH 8.8 or newer (e.g. Ubuntu 22.04) is broken because the cluster catalog (which contains the upgrade to ArgoCD 2.3.12) can't be cloned.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
