### PR TITLE
If ArgoCD operator is present, update the operator's secret to adjust password

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -27,6 +27,7 @@ var (
 	argoRbacConfigMapName = "argocd-rbac-cm"
 	argoConfigMapName     = "argocd-cm"
 	argoSecretName        = "argocd-secret"
+	argoClusterSecretName = "syn-argocd-cluster"
 	argoRbacName          = "argocd-application-controller"
 	argoRootAppName       = "root"
 	argoProjectName       = "syn"

--- a/pkg/argocd/secret.go
+++ b/pkg/argocd/secret.go
@@ -1,6 +1,7 @@
 package argocd
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -31,14 +32,29 @@ func CreateArgoSecret(ctx context.Context, config *rest.Config, namespace, passw
 	if err != nil {
 		return err
 	}
+	clusterSecret, err := clientset.CoreV1().Secrets(namespace).Get(ctx, argoClusterSecretName, metav1.GetOptions{})
+	if err == nil {
+		// If the operator-managed cluster secret exists, the password is updated there instead
+		currentPw := clusterSecret.Data["admin.password"]
+		if bytes.Compare(currentPw, []byte(password)) == 0 {
+			return nil
+		}
+		if clusterSecret.StringData == nil {
+			clusterSecret.StringData = map[string]string{}
+		}
+		clusterSecret.StringData["admin.password"] = password
+		clusterSecret.StringData["admin.passwordMtime"] = mtime
+		_, err = clientset.CoreV1().Secrets(namespace).Update(ctx, clusterSecret, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		klog.Info("Argo CD Cluster secret updated with new password")
+		return nil
+	}
+
 	pwHash := string(pwHashBytes)
 	secret, err := clientset.CoreV1().Secrets(namespace).Get(ctx, argoSecretName, metav1.GetOptions{})
 	if err == nil {
-		clusterSecret, err := clientset.CoreV1().Secrets(namespace).Get(ctx, argoClusterSecretName, metav1.GetOptions{})
-		if err == nil {
-			// If the operator-managed cluster secret exists, the password is updated there instead
-			secret = clusterSecret
-		}
 		currentPwHash := secret.Data["admin.password"]
 		err = bcrypt.CompareHashAndPassword(currentPwHash, []byte(password))
 		if err == nil {


### PR DESCRIPTION
Otherwise steward competes with the operator to manage the argocd password.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
