### PR TITLE
Add ArgoCD sync options to prevent premature pruning of bootstrap deployment

### DIFF
--- a/pkg/argocd/app-controller.go
+++ b/pkg/argocd/app-controller.go
@@ -22,11 +22,13 @@ func createApplicationControllerStatefulSet(ctx context.Context, clientset *kube
 	for k, v := range argoLabels {
 		labels[k] = v
 	}
+	annotations := argoAnnotations
 	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels:    labels,
+			Annotations: annotations,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -18,6 +18,10 @@ var (
 	argoLabels = map[string]string{
 		"app.kubernetes.io/part-of":   "argocd",
 		"argocd.argoproj.io/instance": "argocd",
+		"steward.syn.tools/bootstrap": "true",
+	}
+	argoAnnotations = map[string]string{
+		"argocd.argoproj.io/sync-options": "Prune=false",
 	}
 	argoSSHSecretName     = "argo-ssh-key"
 	argoSSHPublicKey      = "sshPublicKey"

--- a/pkg/argocd/redis.go
+++ b/pkg/argocd/redis.go
@@ -22,11 +22,13 @@ func createRedisDeployment(ctx context.Context, clientset *kubernetes.Clientset,
 	for k, v := range argoLabels {
 		labels[k] = v
 	}
+	annotations := argoAnnotations
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels:    labels,
+			Annotations: annotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
@@ -48,6 +50,7 @@ func createRedisDeployment(ctx context.Context, clientset *kubernetes.Clientset,
 			Name:      name,
 			Namespace: namespace,
 			Labels:    labels,
+			Annotations: annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/argocd/repo-server.go
+++ b/pkg/argocd/repo-server.go
@@ -22,11 +22,13 @@ func createRepoServerDeployment(ctx context.Context, clientset *kubernetes.Clien
 	for k, v := range argoLabels {
 		labels[k] = v
 	}
+	annotations := argoAnnotations
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels:    labels,
+			Annotations: argoAnnotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
@@ -47,6 +49,7 @@ func createRepoServerDeployment(ctx context.Context, clientset *kubernetes.Clien
 			Name:      name,
 			Namespace: namespace,
 			Labels:    labels,
+			Annotations: annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/argocd/server.go
+++ b/pkg/argocd/server.go
@@ -22,11 +22,13 @@ func createServerDeployment(ctx context.Context, clientset *kubernetes.Clientset
 	for k, v := range argoLabels {
 		labels[k] = v
 	}
+	annotations := argoAnnotations
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels:    labels,
+			Annotations: annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{


### PR DESCRIPTION
With the new setup, the bootstrap deployment is at some point deleted (to be replaced by the operator-managed one). However, this has to happen after the operator-managed ArgoCD is deployed. To prevent premature pruning, the bootstrap deployment is set to not be auto-pruned. A post-sync job in the ArgoCD component will remove these annotations at the appropriate time.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
