### PR TITLE
Collect OCP OAuth route and additional facts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3
 	k8s.io/klog v1.0.0
+	sigs.k8s.io/controller-runtime v0.16.3
 )
 
 require (
@@ -118,7 +119,6 @@ require (
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
-	sigs.k8s.io/controller-runtime v0.16.3 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/gin-gonic/gin v1.9.1/go.mod h1:hPrL7YrpYKXt5YId3A/Tnip5kqbEAP+KLuI3SU
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
 github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/zapr v1.2.4 h1:QHVo+6stLbfJmYGkQ7uGHUCu5hnAFAj6mDe6Ea0SeOo=
+github.com/go-logr/zapr v1.2.4/go.mod h1:FyHWQIzQORZ0QVE1BtVHv3cKtNLuXsbNLtpuhNapBOA=
 github.com/go-openapi/jsonpointer v0.19.6/go.mod h1:osyAmYz/mB/C3I+WsTTSgw1ONzaLJoLCyoi6/zppojs=
 github.com/go-openapi/jsonpointer v0.20.0 h1:ESKJdU9ASRfaPNOPRx12IUyA1vn3R9GiE3KYD14BXdQ=
 github.com/go-openapi/jsonpointer v0.20.0/go.mod h1:6PGzBjjIIumbLYysB73Klnms1mwnU4G3YHOECG3CedA=
@@ -273,6 +275,8 @@ github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.25.0 h1:4Hvk6GtkucQ790dqmj7l1eEnRdKm3k3ZUrUMS2d5+5c=
+go.uber.org/zap v1.25.0/go.mod h1:JIAUzQIH94IC4fOJQm7gMmBJP5k7wQfdcnYdPoEXJYk=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/arch v0.6.0 h1:S0JTfE48HbRj80+4tbvZDYsJ3tGv6BUU3XxyZ7CirAc=
 golang.org/x/arch v0.6.0/go.mod h1:FEVrYAQjsQXMVJ1nsMoVVXPZg6p2JE2mx8psSWTDQys=

--- a/main.go
+++ b/main.go
@@ -48,6 +48,12 @@ func main() {
 	app.Flag("operator-namespace", "Namespace in which the ArgoCD operator will be running").Default("syn-argocd-operator").StringVar(&agent.OperatorNamespace)
 	app.Flag("argo-image", "Image to be used for the Argo CD deployments").Default(images.DefaultArgoCDImage).StringVar(&agent.ArgoCDImage)
 	app.Flag("redis-image", "Image to be used for the Argo CD Redis deployment").Default(images.DefaultRedisImage).StringVar(&agent.RedisImage)
+	app.
+		Flag(
+			"additional-facts-config-map",
+			"Additional facts added to the dynamic facts in the cluster object. Keys in the config maps data field override existing keys.").
+		Default("additional-facts").
+		StringVar(&agent.AdditionalFactsConfigMap)
 
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 }

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 	app.
 		Flag(
 			"additional-facts-config-map",
-			"Additional facts added to the dynamic facts in the cluster object. Keys in the configmap's data field override existing keys.").
+			"Additional facts added to the dynamic facts in the cluster object. Keys in the configmap's data field can't override existing keys.").
 		Default("additional-facts").
 		StringVar(&agent.AdditionalFactsConfigMap)
 	app.

--- a/main.go
+++ b/main.go
@@ -54,6 +54,18 @@ func main() {
 			"Additional facts added to the dynamic facts in the cluster object. Keys in the config maps data field override existing keys.").
 		Default("additional-facts").
 		StringVar(&agent.AdditionalFactsConfigMap)
+	app.
+		Flag(
+			"ocp-oauth-route-namespace",
+			"Namespace for the OpenShift OAuth route").
+		Default("openshift-authentication").
+		StringVar(&agent.OCPOAuthRouteNamespace)
+	app.
+		Flag(
+			"ocp-oauth-route-name",
+			"Name of the OpenShift OAuth route").
+		Default("oauth-openshift").
+		StringVar(&agent.OCPOAuthRouteName)
 
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 }

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 	app.
 		Flag(
 			"additional-facts-config-map",
-			"Additional facts added to the dynamic facts in the cluster object. Keys in the config maps data field override existing keys.").
+			"Additional facts added to the dynamic facts in the cluster object. Keys in the configmap's data field override existing keys.").
 		Default("additional-facts").
 		StringVar(&agent.AdditionalFactsConfigMap)
 	app.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -12,11 +12,13 @@ import (
 
 	"github.com/deepmap/oapi-codegen/v2/pkg/securityprovider"
 	"github.com/projectsyn/lieutenant-api/pkg/api"
-	"github.com/projectsyn/steward/pkg/argocd"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
+
+	"github.com/projectsyn/steward/pkg/agent/facts"
+	"github.com/projectsyn/steward/pkg/argocd"
 )
 
 // Agent configures the cluster agent
@@ -31,8 +33,10 @@ type Agent struct {
 	OperatorNamespace string
 	ArgoCDImage       string
 	RedisImage        string
+	// The configmap containing additional facts to be added to the dynamic facts
+	AdditionalFactsConfigMap string
 
-	facts factCollector
+	facts facts.FactCollector
 }
 
 // Run starts the cluster agent
@@ -58,8 +62,11 @@ func (a *Agent) Run(ctx context.Context) error {
 		return err
 	}
 
-	a.facts = factCollector{
-		client: client,
+	a.facts = facts.FactCollector{
+		Client: client,
+
+		AdditionalFactsConfigMapNamespace: a.Namespace,
+		AdditionalFactsConfigMapName:      a.AdditionalFactsConfigMap,
 	}
 
 	ticker := time.NewTicker(1 * time.Minute)
@@ -91,7 +98,7 @@ func (a *Agent) registerCluster(ctx context.Context, config *rest.Config, apiCli
 			DeployKey: &publicKey,
 		},
 	}
-	patchCluster.DynamicFacts, err = a.facts.fetchDynamicFacts(ctx)
+	patchCluster.DynamicFacts, err = a.facts.FetchDynamicFacts(ctx)
 	if err != nil {
 		klog.Errorf("Error fetching dynamic facts: %v", err)
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -36,6 +36,10 @@ type Agent struct {
 	// The configmap containing additional facts to be added to the dynamic facts
 	AdditionalFactsConfigMap string
 
+	// Reference to the OpenShift OAuth route to be added to the dynamic facts
+	OCPOAuthRouteNamespace string
+	OCPOAuthRouteName      string
+
 	facts facts.FactCollector
 }
 
@@ -64,6 +68,9 @@ func (a *Agent) Run(ctx context.Context) error {
 
 	a.facts = facts.FactCollector{
 		Client: client,
+
+		OAuthRouteNamespace: a.OCPOAuthRouteNamespace,
+		OAuthRouteName:      a.OCPOAuthRouteName,
 
 		AdditionalFactsConfigMapNamespace: a.Namespace,
 		AdditionalFactsConfigMapName:      a.AdditionalFactsConfigMap,

--- a/pkg/agent/facts/facts.go
+++ b/pkg/agent/facts/facts.go
@@ -16,6 +16,9 @@ import (
 type FactCollector struct {
 	Client *kubernetes.Clientset
 
+	OAuthRouteNamespace string
+	OAuthRouteName      string
+
 	AdditionalFactsConfigMapNamespace string
 	AdditionalFactsConfigMapName      string
 }

--- a/pkg/agent/facts/facts.go
+++ b/pkg/agent/facts/facts.go
@@ -25,6 +25,15 @@ type FactCollector struct {
 
 func (col FactCollector) FetchDynamicFacts(ctx context.Context) (*api.DynamicClusterFacts, error) {
 	facts := api.DynamicClusterFacts{}
+
+	additionalFacts, err := col.fetchAdditionalFacts(ctx)
+	if err != nil {
+		klog.Errorf("Error fetching additional facts: %v", err)
+	}
+	for k, v := range additionalFacts {
+		facts[k] = v
+	}
+
 	kubeVersion, err := col.fetchKubernetesVersion(ctx)
 	if err != nil {
 		klog.Errorf("Error fetching kubernetes version: %v", err)
@@ -47,14 +56,6 @@ func (col FactCollector) FetchDynamicFacts(ctx context.Context) (*api.DynamicClu
 	}
 	if ocpOAuthRoute != "" {
 		facts["openshiftOAuthRoute"] = ocpOAuthRoute
-	}
-
-	additionalFacts, err := col.fetchAdditionalFacts(ctx)
-	if err != nil {
-		klog.Errorf("Error fetching additional facts: %v", err)
-	}
-	for k, v := range additionalFacts {
-		facts[k] = v
 	}
 
 	return &facts, nil

--- a/pkg/agent/facts/facts_test.go
+++ b/pkg/agent/facts/facts_test.go
@@ -1,4 +1,4 @@
-package agent
+package facts
 
 import (
 	"testing"

--- a/pkg/agent/facts/factsopenshift.go
+++ b/pkg/agent/facts/factsopenshift.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"strings"
 	"time"
 
@@ -55,7 +56,10 @@ func (col FactCollector) fetchOpenshiftVersion(ctx context.Context) (*SemanticVe
 }
 
 func (col FactCollector) fetchOpenshiftOAuthRoute(ctx context.Context) (string, error) {
-	body, err := col.Client.RESTClient().Get().AbsPath("/apis/route.openshift.io/v1/namespaces/openshift-authentication/routes/oauth-openshift").Do(ctx).Raw()
+	body, err := col.Client.RESTClient().Get().
+		AbsPath(
+			path.Join("/apis/route.openshift.io/v1/namespaces", col.OAuthRouteNamespace, "routes", col.OAuthRouteName),
+		).Do(ctx).Raw()
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// API server doesn't know `routes` or there is no resource, so we are not running on openshift.

--- a/pkg/agent/facts/factsopenshift.go
+++ b/pkg/agent/facts/factsopenshift.go
@@ -1,4 +1,4 @@
-package agent
+package facts
 
 import (
 	"context"
@@ -30,8 +30,14 @@ type OpenshiftVersion struct {
 	Status OpenshiftVersionStatus
 }
 
-func (col factCollector) fetchOpenshiftVersion(ctx context.Context) (*SemanticVersion, error) {
-	body, err := col.client.RESTClient().Get().AbsPath("/apis/config.openshift.io/v1/clusterversions/version").Do(ctx).Raw()
+type OpenshiftRoute struct {
+	Spec struct {
+		Host string
+	}
+}
+
+func (col FactCollector) fetchOpenshiftVersion(ctx context.Context) (*SemanticVersion, error) {
+	body, err := col.Client.RESTClient().Get().AbsPath("/apis/config.openshift.io/v1/clusterversions/version").Do(ctx).Raw()
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// API server doesn't know `clusterversions` or there is no resource, so we are not running on openshift.
@@ -46,6 +52,24 @@ func (col factCollector) fetchOpenshiftVersion(ctx context.Context) (*SemanticVe
 	}
 
 	return processOpenshiftVersion(version)
+}
+
+func (col FactCollector) fetchOpenshiftOAuthRoute(ctx context.Context) (string, error) {
+	body, err := col.Client.RESTClient().Get().AbsPath("/apis/route.openshift.io/v1/namespaces/openshift-authentication/routes/oauth-openshift").Do(ctx).Raw()
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// API server doesn't know `routes` or there is no resource, so we are not running on openshift.
+			return "", nil
+		}
+		return "", fmt.Errorf("unable to fetch the openshift route: %w", err)
+	}
+	var route OpenshiftRoute
+	err = json.Unmarshal(body, &route)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse the openshift route: %w", err)
+	}
+
+	return route.Spec.Host, nil
 }
 
 type SemanticVersion struct {

--- a/pkg/agent/facts/factsopenshift_test.go
+++ b/pkg/agent/facts/factsopenshift_test.go
@@ -1,4 +1,4 @@
-package agent
+package facts
 
 import (
 	"testing"

--- a/tools/dynamic_fact_collector/main.go
+++ b/tools/dynamic_fact_collector/main.go
@@ -15,6 +15,10 @@ import (
 func main() {
 	ns := flag.String("namespace", "syn", "namespace in which steward is running")
 	additionalFactsConfigMap := flag.String("additional-facts-config-map", "additional-facts", "configmap containing additional facts to be added to the dynamic facts")
+	ocpOAuthRouteNamespace := flag.String("ocp-oauth-route-namespace", "openshift-authentication", "Namespace for the OpenShift OAuth route")
+	ocpOAuthRouteName := flag.String("ocp-oauth-route-name", "oauth-openshift", "Name of the OpenShift OAuth route")
+
+	flag.Parse()
 
 	cfg := config.GetConfigOrDie()
 
@@ -25,6 +29,9 @@ func main() {
 
 	c := facts.FactCollector{
 		Client: client,
+
+		OAuthRouteNamespace: *ocpOAuthRouteNamespace,
+		OAuthRouteName:      *ocpOAuthRouteName,
 
 		AdditionalFactsConfigMapNamespace: *ns,
 		AdditionalFactsConfigMapName:      *additionalFactsConfigMap,

--- a/tools/dynamic_fact_collector/main.go
+++ b/tools/dynamic_fact_collector/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/projectsyn/steward/pkg/agent/facts"
+)
+
+func main() {
+	ns := flag.String("namespace", "syn", "namespace in which steward is running")
+	additionalFactsConfigMap := flag.String("additional-facts-config-map", "additional-facts", "configmap containing additional facts to be added to the dynamic facts")
+
+	cfg := config.GetConfigOrDie()
+
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	c := facts.FactCollector{
+		Client: client,
+
+		AdditionalFactsConfigMapNamespace: *ns,
+		AdditionalFactsConfigMapName:      *additionalFactsConfigMap,
+	}
+
+	fcts, err := c.FetchDynamicFacts(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	out, err := json.MarshalIndent(fcts, "", "\t")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(out))
+}


### PR DESCRIPTION
Collects the OCP4 OAuth route information and additional facts supplied by a ConfigMap

Since we do not really have any tests I added an executable package `go run ./tools/dynamic_fact_collector` to test fact collection.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
