### PR TITLE
Limit ArgoCD password seed to the max length bcrypt allows

### DIFF
--- a/pkg/argocd/secret.go
+++ b/pkg/argocd/secret.go
@@ -27,6 +27,11 @@ func CreateArgoSecret(ctx context.Context, config *rest.Config, namespace, passw
 	if err != nil {
 		return err
 	}
+	// bcrypt supports a maximum of 72 bytes for the password
+	// https://cs.opensource.google/go/x/crypto/+/bc7d1d1eb54b3530da4f5ec31625c95d7df40231
+	if len(password) > 72 {
+		password = password[:72]
+	}
 	pwHashBytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	mtime := time.Now().Format(time.RFC3339)
 	if err != nil {


### PR DESCRIPTION
> By design, bcrypt only uses the first 72 bytes of a password when
generating a hash. Most implementations, including the reference one,
simply silently ignore any trailing input when provided passwords longer
than 72 bytes. This can cause confusion for users who expect the entire
password to be used to generate the hash.

https://cs.opensource.google/go/x/crypto/+/bc7d1d1eb54b3530da4f5ec31625c95d7df40231

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
