### PR TITLE
Add support for bootstrapping additional root apps

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,12 @@ func main() {
 		StringVar(&agent.AdditionalFactsConfigMap)
 	app.
 		Flag(
+			"additional-root-apps-config-map",
+			"Config map holding metadata for additional ArgoCD root apps and app projects.").
+		Default("additional-root-apps").
+		StringVar(&agent.AdditionalRootAppsConfigMap)
+	app.
+		Flag(
 			"ocp-oauth-route-namespace",
 			"Namespace for the OpenShift OAuth route").
 		Default("openshift-authentication").

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -36,6 +36,9 @@ type Agent struct {
 	// The configmap containing additional facts to be added to the dynamic facts
 	AdditionalFactsConfigMap string
 
+	// The configmap containing metadata for additional root apps to deploy
+	AdditionalRootAppsConfigMap string
+
 	// Reference to the OpenShift OAuth route to be added to the dynamic facts
 	OCPOAuthRouteNamespace string
 	OCPOAuthRouteName      string
@@ -140,7 +143,7 @@ func (a *Agent) registerCluster(ctx context.Context, config *rest.Config, apiCli
 		return
 	}
 
-	if err := argocd.Apply(ctx, config, a.Namespace, a.OperatorNamespace, a.ArgoCDImage, a.RedisImage, apiClient, cluster); err != nil {
+	if err := argocd.Apply(ctx, config, a.Namespace, a.OperatorNamespace, a.ArgoCDImage, a.RedisImage, a.AdditionalRootAppsConfigMap, apiClient, cluster); err != nil {
 		klog.Error(err)
 	}
 }

--- a/pkg/argocd/argo-app.go
+++ b/pkg/argocd/argo-app.go
@@ -2,13 +2,17 @@ package argocd
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/projectsyn/lieutenant-api/pkg/api"
+	"k8s.io/apimachinery/pkg/api/errors"
 	k8err "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 )
@@ -23,9 +27,32 @@ var (
 	argoProjectGVR = argoGroupVersion.WithResource("appprojects")
 
 	localKubernetesAPI = "https://kubernetes.default.svc"
+
+	additionalRootAppsConfigKey = "teams"
 )
 
-func createArgoProject(ctx context.Context, cluster *api.Cluster, config *rest.Config, namespace string) error {
+func readAdditionalRootAppsConfigMap(ctx context.Context, clientset *kubernetes.Clientset, namespace, additionalRootAppsConfigMapName string) ([]string, error) {
+	cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(ctx, additionalRootAppsConfigMapName, v1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			klog.Info("Additional root apps config map not present")
+			return []string{}, nil
+		} else {
+			return nil, fmt.Errorf("unable to fetch the additional root apps config map: %w", err)
+		}
+	}
+	teamsJson, ok := cm.Data[additionalRootAppsConfigKey]
+	if !ok {
+		return nil, fmt.Errorf("additional root apps ConfigMap doesn't have key %s", additionalRootAppsConfigKey)
+	}
+	var teams []string
+	if err := json.Unmarshal([]byte(teamsJson), &teams); err != nil {
+		return nil, fmt.Errorf("unmarshalling additional root apps ConfigMap contents: %v", err)
+	}
+	return teams, nil
+}
+
+func createArgoProject(ctx context.Context, cluster *api.Cluster, config *rest.Config, namespace, name string) error {
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return err
@@ -36,7 +63,7 @@ func createArgoProject(ctx context.Context, cluster *api.Cluster, config *rest.C
 			"apiVersion": argoProjectGVR.Group + "/" + argoProjectGVR.Version,
 			"kind":       "AppProject",
 			"metadata": map[string]interface{}{
-				"name": argoProjectName,
+				"name": name,
 			},
 			"spec": map[string]interface{}{
 				"clusterResourceWhitelist": []map[string]interface{}{{
@@ -56,17 +83,17 @@ func createArgoProject(ctx context.Context, cluster *api.Cluster, config *rest.C
 
 	if _, err = argoProjectClient.Namespace(namespace).Create(ctx, project, v1.CreateOptions{}); err != nil {
 		if k8err.IsAlreadyExists(err) {
-			klog.Warning("Argo Project already exists, skip")
+			klog.Warning("Argo Project already exists, skipping... app=", name)
 		} else {
 			return err
 		}
 	} else {
-		klog.Info("Argo Project created")
+		klog.Info("Argo Project created: ", name)
 	}
 	return nil
 }
 
-func createArgoApp(ctx context.Context, cluster *api.Cluster, config *rest.Config, namespace string) error {
+func createArgoApp(ctx context.Context, cluster *api.Cluster, config *rest.Config, namespace, projectName, name, appsPath string) error {
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return err
@@ -77,13 +104,13 @@ func createArgoApp(ctx context.Context, cluster *api.Cluster, config *rest.Confi
 			"apiVersion": argoAppGVR.Group + "/" + argoAppGVR.Version,
 			"kind":       "Application",
 			"metadata": map[string]interface{}{
-				"name": argoRootAppName,
+				"name": name,
 			},
 			"spec": map[string]interface{}{
-				"project": argoProjectName,
+				"project": projectName,
 				"source": map[string]interface{}{
 					"repoURL":        *cluster.GitRepo.Url,
-					"path":           argoAppsPath,
+					"path":           appsPath + "/",
 					"targetRevision": "HEAD",
 				},
 				"syncPolicy": map[string]interface{}{
@@ -102,12 +129,12 @@ func createArgoApp(ctx context.Context, cluster *api.Cluster, config *rest.Confi
 
 	if _, err = argoAppClient.Namespace(namespace).Create(ctx, app, v1.CreateOptions{}); err != nil {
 		if k8err.IsAlreadyExists(err) {
-			klog.Warning("Argo App already exists, skip")
+			klog.Warning("Argo App already exists, skipping... app=", name)
 		} else {
 			return err
 		}
 	} else {
-		klog.Info("Argo App created")
+		klog.Info("Argo App created: ", name)
 	}
 	return nil
 }

--- a/pkg/argocd/argo-app.go
+++ b/pkg/argocd/argo-app.go
@@ -58,6 +58,11 @@ func createArgoProject(ctx context.Context, cluster *api.Cluster, config *rest.C
 		return err
 	}
 	argoProjectClient := dynamicClient.Resource(argoProjectGVR)
+
+	if _, err = argoProjectClient.Namespace(namespace).Get(ctx, name, v1.GetOptions{}); err == nil {
+		return nil
+	}
+
 	project := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": argoProjectGVR.Group + "/" + argoProjectGVR.Version,
@@ -99,6 +104,11 @@ func createArgoApp(ctx context.Context, cluster *api.Cluster, config *rest.Confi
 		return err
 	}
 	argoAppClient := dynamicClient.Resource(argoAppGVR)
+
+	if _, err = argoAppClient.Namespace(namespace).Get(ctx, name, v1.GetOptions{}); err == nil {
+		return nil
+	}
+
 	app := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": argoAppGVR.Group + "/" + argoAppGVR.Version,

--- a/pkg/argocd/argo-app.go
+++ b/pkg/argocd/argo-app.go
@@ -125,7 +125,7 @@ func createArgoApp(ctx context.Context, cluster *api.Cluster, config *rest.Confi
 				},
 				"syncPolicy": map[string]interface{}{
 					"automated": map[string]interface{}{
-						"prune":    true,
+						"prune":    false,
 						"selfHeal": true,
 					},
 				},


### PR DESCRIPTION
See [SDD-0030 - ArgoCD multitenancy] for the overall design for additional root apps.

This commit introduces a new command line flag to specify a config map name from which Steward will read a JSON-encoded list of team names for which to setup additional ArgoCD AppProject and root Application (app of apps) resources.

Steward uses the team names as is for the additional AppProject resources, and creates the additional root apps as `root-<team name>`. As defined in the design document, the path for the root apps is configured as `manifests/apps-<team name>/`.

[SDD-0030 - ArgoCD multitenancy]: https://syn.tools/syn/SDDs/0030-argocd-multitenancy.html

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
