### PR TITLE
Fix listing of ArgoCD custom resource when CRD isn't installed

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -59,16 +59,15 @@ func Apply(ctx context.Context, config *rest.Config, namespace, operatorNamespac
 		Resource: "argocds",
 	}
 
+	if err = applyAdditionalRootApps(ctx, clientset, config, namespace, additionalRootAppsConfigMapName, cluster); err != nil {
+		return err
+	}
+
 	argos, err := dynamicClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
 
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
-
-	if err = applyAdditionalRootApps(ctx, clientset, config, namespace, additionalRootAppsConfigMapName, cluster); err != nil {
-		return err
-	}
-
 	if err == nil && len(argos.Items) > 0 {
 		// An ArgoCD custom resource exists in our namespace
 		err = fixArgoOperatorDeadlock(ctx, clientset, config, namespace, operatorNamespace)


### PR DESCRIPTION
We incorrectly inserted the additional argocd root app creation between two checks of the error code returned by the ArgoCD custom resource list call.

Fixes #158 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
