### PR TITLE
Improved HTTP connection managment to lieutenant-api

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -128,6 +128,8 @@ func (a *Agent) registerCluster(ctx context.Context, config *rest.Config, apiCli
 		klog.Error(err)
 		return
 	}
+	defer resp.Body.Close()
+	defer io.Copy(io.Discard, resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		reason := &api.Reason{}
 		if err := json.NewDecoder(resp.Body).Decode(reason); err != nil {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -145,7 +145,7 @@ func (a *Agent) registerCluster(ctx context.Context, config *rest.Config, apiCli
 		return
 	}
 
-	if err := argocd.Apply(ctx, config, a.Namespace, a.OperatorNamespace, a.ArgoCDImage, a.RedisImage, a.AdditionalRootAppsConfigMap, apiClient, cluster); err != nil {
+	if err := argocd.Apply(ctx, config, a.Namespace, a.OperatorNamespace, a.ArgoCDImage, a.RedisImage, a.AdditionalRootAppsConfigMap, cluster); err != nil {
 		klog.Error(err)
 	}
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -94,6 +94,9 @@ func (a *Agent) Run(ctx context.Context) error {
 }
 
 func (a *Agent) registerCluster(ctx context.Context, config *rest.Config, apiClient *api.Client) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
 	publicKey, err := argocd.CreateSSHSecret(ctx, config, a.Namespace)
 	if err != nil {
 		klog.Errorf("Error creating SSH secret: %v", err)

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -42,7 +42,7 @@ var (
 )
 
 // Apply reconciles the Argo CD deployments
-func Apply(ctx context.Context, config *rest.Config, namespace, operatorNamespace, argoImage, redisArgoImage, additionalRootAppsConfigMapName string, apiClient *api.Client, cluster *api.Cluster) error {
+func Apply(ctx context.Context, config *rest.Config, namespace, operatorNamespace, argoImage, redisArgoImage, additionalRootAppsConfigMapName string, cluster *api.Cluster) error {
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return err
@@ -101,10 +101,10 @@ func Apply(ctx context.Context, config *rest.Config, namespace, operatorNamespac
 	}
 
 	klog.Infof("Found %d of expected %d deployments, found %d of expected %d statefulsets, bootstrapping now", foundDeploymentCount, expectedDeploymentCount, foundStatefulSetCount, expectedStatefulSetCount)
-	return bootstrapArgo(ctx, clientset, config, namespace, argoImage, redisArgoImage, apiClient, cluster)
+	return bootstrapArgo(ctx, clientset, config, namespace, argoImage, redisArgoImage, cluster)
 }
 
-func bootstrapArgo(ctx context.Context, clientset *kubernetes.Clientset, config *rest.Config, namespace, argoImage, redisArgoImage string, apiClient *api.Client, cluster *api.Cluster) error {
+func bootstrapArgo(ctx context.Context, clientset *kubernetes.Clientset, config *rest.Config, namespace, argoImage, redisArgoImage string, cluster *api.Cluster) error {
 	if err := createArgoCDConfigMaps(ctx, cluster, clientset, namespace); err != nil {
 		return err
 	}


### PR DESCRIPTION
This will most likely fix a high IO bug we found after steward runs for a while.

PR contains:
* Correctly close response bodies from lieutenant-api. Prevents keep-alive leaks among others.
* Timeout requests around the time the request is retried.
* Some cleanup

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
