### PR TITLE
Adjust `make docker` and Dockerfile to have clean version for tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM docker.io/golang:1.25 as build
 
+ARG VERSION
+
 WORKDIR /app
 
 COPY go.mod go.sum ./

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ clean:
 
 .PHONY: docker
 docker:
-	docker build -t $(IMAGE_NAME) .
+	docker build --build-arg VERSION=$(VERSION) -t $(IMAGE_NAME) .
 	@echo built image $(IMAGE_NAME)
 
 .PHONY: docs-serve


### PR DESCRIPTION
Not sure why `git describe --tags --always --dirty --match=v*` always has suffix `-dirty` for the container image build even when run on a tagged commit in a clean working directory. The command correctly returns just the tag in the Makefile for the same checkout state, so we simply introduce a `VERSION` build argument in the Dockerfile to use the correct command output for the final binary built in the container image.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
