### PR TITLE
Add logic in Steward to delete bootstrap ArgoCD

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -10,8 +10,10 @@ Also see the xref:syn:SDDs:0009-steward-cluster-agent.adoc[SDD 0009 - Steward Cl
 
 The Steward cluster agent is the first part of Project Syn that's installed on a new cluster to manage it. It connects to the xref:lieutenant-api::home.adoc[Lieutenant API] to receive the necessary configuration and to report back the cluster state.
 
-This is done once per minute. It also checks on each run if the Argo CD components are deployed (exist) and bootstraps them if they don't exist.
+This is done once per minute.
+It also checks on each run if the Argo CD components are deployed (`ArgoCD` custom resource or components exist) and bootstraps them if they don't exist.
 
+Additionally, Steward will delete the bootstrap Argo CD components (labeled `steward.syn.tools/bootstrap=true`) when it sees that an ArgoCD operator `ArgoCD` custom resource exists.
 
 == API Communication
 

--- a/pkg/argocd/app-controller.go
+++ b/pkg/argocd/app-controller.go
@@ -22,13 +22,11 @@ func createApplicationControllerStatefulSet(ctx context.Context, clientset *kube
 	for k, v := range argoLabels {
 		labels[k] = v
 	}
-	annotations := argoAnnotations
 	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Labels:      labels,
-			Annotations: annotations,
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -20,7 +20,6 @@ import (
 var (
 	argoLabels = map[string]string{
 		"app.kubernetes.io/part-of":   "argocd",
-		"argocd.argoproj.io/instance": "argocd",
 		"steward.syn.tools/bootstrap": "true",
 	}
 	argoAnnotations = map[string]string{
@@ -78,6 +77,10 @@ func Apply(ctx context.Context, config *rest.Config, namespace, operatorNamespac
 		err = fixArgoOperatorDeadlock(ctx, clientset, config, namespace, operatorNamespace)
 		if err != nil {
 			return fmt.Errorf("could not fix argocd operator deadlock: %w", err)
+		}
+		err = deleteBootstrapArgoCD(ctx, clientset, namespace)
+		if err != nil {
+			return fmt.Errorf("could not delete bootstrap argocd: %w", err)
 		}
 		return nil
 	}
@@ -200,6 +203,41 @@ func fixArgoOperatorDeadlock(ctx context.Context, clientset *kubernetes.Clientse
 	}
 
 	return multierr.Combine(errors...)
+}
+
+func deleteBootstrapArgoCD(ctx context.Context, clientset *kubernetes.Clientset, namespace string) error {
+	klog.Info("Deleting bootstrap ArgoCD components (if there are any left)...")
+
+	errs := []error{}
+	err := clientset.AppsV1().Deployments(namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+		LabelSelector: "steward.syn.tools/bootstrap=true",
+	})
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	err = clientset.AppsV1().StatefulSets(namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+		LabelSelector: "steward.syn.tools/bootstrap=true",
+	})
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	services, err := clientset.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "steward.syn.tools/bootstrap=true",
+	})
+	if err == nil {
+		for _, svc := range services.Items {
+			err = clientset.CoreV1().Services(namespace).Delete(ctx, svc.Name, metav1.DeleteOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				errs = append(errs, err)
+			}
+		}
+	} else {
+		errs = append(errs, err)
+	}
+
+	return multierr.Combine(errs...)
 }
 
 func applyAdditionalRootApps(ctx context.Context, clientset *kubernetes.Clientset, config *rest.Config, namespace, additionalRootAppsConfigMapName string, cluster *api.Cluster) error {

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -22,9 +22,6 @@ var (
 		"app.kubernetes.io/part-of":   "argocd",
 		"steward.syn.tools/bootstrap": "true",
 	}
-	argoAnnotations = map[string]string{
-		"argocd.argoproj.io/sync-options": "Prune=false",
-	}
 	argoSSHSecretName      = "argo-ssh-key"
 	argoSSHPublicKey       = "sshPublicKey"
 	argoSSHPrivateKey      = "sshPrivateKey"

--- a/pkg/argocd/redis.go
+++ b/pkg/argocd/redis.go
@@ -22,13 +22,11 @@ func createRedisDeployment(ctx context.Context, clientset *kubernetes.Clientset,
 	for k, v := range argoLabels {
 		labels[k] = v
 	}
-	annotations := argoAnnotations
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Labels:      labels,
-			Annotations: annotations,
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
@@ -47,10 +45,9 @@ func createRedisDeployment(ctx context.Context, clientset *kubernetes.Clientset,
 	}
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Labels:      labels,
-			Annotations: annotations,
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/argocd/repo-server.go
+++ b/pkg/argocd/repo-server.go
@@ -22,13 +22,11 @@ func createRepoServerDeployment(ctx context.Context, clientset *kubernetes.Clien
 	for k, v := range argoLabels {
 		labels[k] = v
 	}
-	annotations := argoAnnotations
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Labels:      labels,
-			Annotations: argoAnnotations,
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
@@ -46,10 +44,9 @@ func createRepoServerDeployment(ctx context.Context, clientset *kubernetes.Clien
 	}
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Labels:      labels,
-			Annotations: annotations,
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/argocd/server.go
+++ b/pkg/argocd/server.go
@@ -22,13 +22,11 @@ func createServerDeployment(ctx context.Context, clientset *kubernetes.Clientset
 	for k, v := range argoLabels {
 		labels[k] = v
 	}
-	annotations := argoAnnotations
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Labels:      labels,
-			Annotations: annotations,
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{


### PR DESCRIPTION
This PR introduces a new method which deletes the bootstrap ArgoCD resources (`deployments`, `statefulsets` and `services` with label `steward.syn.tools/bootstrap=true`). This method is called once a minute as soon as Steward sees that an `ArgoCD` custom resource is present on the cluster.

This should reduce the complexity and brittleness of the cluster bootstrap process by completely encapsulating the responsibility for bootstrap cleanup in Steward, rather than having part of the cleanup in component-argocd.

Additionally, the PR removes the now unnecessary ArgoCD sync-options annotations from the bootstrap ArgoCD resources.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
